### PR TITLE
Auto display

### DIFF
--- a/example.hs
+++ b/example.hs
@@ -9,17 +9,28 @@ import "base" Data.Int ( Int )
 import "base" Prelude ( (+) )
 import "base" System.IO ( IO, hSetBuffering, BufferMode(NoBuffering), stdout, putStrLn )
 import "base-unicode-symbols" Prelude.Unicode ( ℤ )
-import "terminal-progress-bar" System.ProgressBar ( progressBar, percentage, exact )
+import "terminal-progress-bar" System.ProgressBar ( progressBar, percentage, exact, startProgress, incProgress )
 
 
 main ∷ IO ()
-main = example 60 (13 + 60) 25000
+main = do
+  example 60 (13 + 60) 25000
+  example' 60 (13 + 60) 25000
 
 example ∷ ℤ → ℤ → Int → IO ()
 example t w delay = do
     hSetBuffering stdout NoBuffering
     forM_ [1..t] $ \d → do
       progressBar percentage exact w d t
+      threadDelay delay
+    putStrLn ""
+
+example' ∷ ℤ → ℤ → Int → IO ()
+example' t w delay = do
+    hSetBuffering stdout NoBuffering
+    (pr, _) <- startProgress percentage exact w t
+    forM_ [1..t] $ \d → do
+      incProgress pr 1
       threadDelay delay
     putStrLn ""
 

--- a/terminal-progress-bar.cabal
+++ b/terminal-progress-bar.cabal
@@ -43,6 +43,9 @@ library
     hs-source-dirs: src
     build-depends: base                 >= 3.0.3.1 && < 4.7
                  , base-unicode-symbols >= 0.2.2.3 && < 0.3
+                 , base-unicode-symbols >= 0.2.2.3 && < 0.3
+                 , stm                  >= 2.4     && < 3.0
+                 , stm-chans            >= 3.0.0   && < 4.0
     exposed-modules: System.ProgressBar
     ghc-options: -Wall
 


### PR DESCRIPTION
Add support for auto-display progress bar

This would resolve #4

A couple notes:
- this adds a dependency on `stm` and `stm-chans`, which should be
  pretty uncontroversial.
- I don't take a starting position in the auto-display form. It would be
  trivial to add but I think the aim with that function is to cover the
  common case, which is to start progress at 0 and have it manage
  displaying the progress.
- Added an example to examples.hs to show the usage.
- I would have added stuff to the README but it is blank, so that's a
  topic for another pull request ;)

Please let me know if you have any issues or things you'd like changed
with this PR.
