### PR TITLE
update for newer ghc: more liberal bound for `base`  package

### DIFF
--- a/terminal-progress-bar.cabal
+++ b/terminal-progress-bar.cabal
@@ -41,7 +41,7 @@ flag example
 
 library
     hs-source-dirs: src
-    build-depends: base                 >= 3.0.3.1 && < 4.7
+    build-depends: base                 >= 3.0.3.1 && < 5.0
                  , base-unicode-symbols >= 0.2.2.3 && < 0.3
                  , base-unicode-symbols >= 0.2.2.3 && < 0.3
                  , stm                  >= 2.4     && < 3.0
@@ -54,7 +54,7 @@ test-suite test-terminal-progress-bar
   main-is: test.hs
   hs-source-dirs: test
   ghc-options: -Wall
-  build-depends: base                  >= 3.0.3.1 && < 4.7
+  build-depends: base                  >= 3.0.3.1 && < 5.0
                , base-unicode-symbols  >= 0.2.2.3 && < 0.3
                , HUnit                 >= 1.2.4.2 && < 1.3
                , terminal-progress-bar


### PR DESCRIPTION
Update for new ghc package.
