### PR TITLE
Fix divide by zero error in remainingTime label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+dist-newstyle

--- a/lib/src/System/ProgressBar.hs
+++ b/lib/src/System/ProgressBar.hs
@@ -568,8 +568,8 @@ remainingTime
 remainingTime formatNDT altMsg = Label render
   where
     render progress timing
-        | dt > 1 = formatNDT estimatedRemainingTime
         | progressDone progress <= 0 = altMsg
+        | dt > 1 = formatNDT estimatedRemainingTime
         | otherwise = altMsg
       where
         estimatedRemainingTime = estimatedTotalTime - dt


### PR DESCRIPTION
The `remainingTime` label can crash with a divide by zero error if some time has passed where `progressDone` is zero while `progressTodo` is greater than zero. This is because `progressFraction` evaluates to zero which causes `recip progressFraction` to fail.

This PR fixes this by reordering the existing condition that checks `progressDone` for a zero value so that it prevents the error.

I have added test cases for this function. The specific case that exhibits the error without the fix is `No progress after some time`.

This is likely the issue that #28 is trying to fix, so if you choose to merge this fix, you can probably close that PR too.